### PR TITLE
Fix errors for JNI

### DIFF
--- a/javacli/Connection.java
+++ b/javacli/Connection.java
@@ -184,11 +184,11 @@ public class Connection {
     /**
      * Create table matching specified class.  Name of the table is equal
      * to class name without any package prefixes. This table will include columns
-     * corresponsinf to all non-static and non-transient fields of specified class and base classes
+     * corresponding to all non-static and non-transient fields of specified class and base classes
      * of this class. 
      * @param cls Java class for which table should be created.
-     * @return <code>true</code> if table sucessfully created, <code>false</code> if table already exists
-     * @exception throws CliError exception in case of all other errors (except table already exists)
+     * @return <code>true</code> if table successfully created, <code>false</code> if table already exists
+     * @exception CliError exception in case of all other errors (except table already exists)
      */
     public boolean createTable(Class cls) 
     {
@@ -199,13 +199,13 @@ public class Connection {
     /**
      * Create table matching specified class.  Name of the table is equal
      * to class name without any package prefixes. This table will include columns
-     * corresponsinf to all non-static and non-transient fields of specified class and base classes
+     * corresponding to all non-static and non-transient fields of specified class and base classes
      * of this class. 
      * @param cls Java class for which table should be created.
      * @param referenceMap map to provide names of referenced tables for reference fields.
      * Key of this map is field name.
      * @return <code>true</code> if table sucessfully created, <code>false</code> if table already exists
-     * @exception throws CliError exception in case of all other errors (except table already exists)
+     * @exception CliError exception in case of all other errors (except table already exists)
      */
     public boolean createTable(Class cls, HashMap referenceMap) 
     {

--- a/jnicli/Cursor.java
+++ b/jnicli/Cursor.java
@@ -24,7 +24,7 @@ public interface Cursor { // extends Enumeration { // if Cursor is derived from 
      * object has at least one more element to provide.
      *
      * @return     the next element of this enumeration.
-     * @exception  NoSuchElementException  if no more elements exist.
+     * @exception  java.util.NoSuchElementException  if no more elements exist.
      */
     Object nextElement();
 

--- a/jnicli/DatabaseJNI.java
+++ b/jnicli/DatabaseJNI.java
@@ -19,9 +19,9 @@ public class DatabaseJNI implements Database {
                 classes.put(c, desc);
                 desc.td = jniUpdateTable(db, table, getTableDescriptor(desc)); 
             } catch (ClassNotFoundException x) { 
-                new CliException("Class '" + table + "' not found");
+                throw new CliException("Class '" + table + "' not found");
             } catch (Exception x) { 
-                new CliException(x.getMessage());
+                throw new CliException(x.getMessage());
             }
         }
     }

--- a/jnicli/jnicli.cpp
+++ b/jnicli/jnicli.cpp
@@ -316,13 +316,13 @@ class JniDatabase : public dbDatabase {
             return;
         }
         dbTable* table = (dbTable*)getRow(dbMetaTableId);
-        dbTableDescriptor* metatable = new dbTableDescriptor(table);
+        dbTableDescriptor* metatable = new dbTableDescriptor(this, table);
         linkTable(metatable, dbMetaTableId);
         oid_t tid = table->firstRow;
         nextTableId = tid;
         while (tid != 0) {
             table = (dbTable*)getRow(tid);
-            dbTableDescriptor* desc = new dbTableDescriptor(table);
+            dbTableDescriptor* desc = new dbTableDescriptor(this, table);
             linkTable(desc, tid);
             desc->setFlags();
             tid = table->next;
@@ -635,7 +635,7 @@ void JNICALL   jniSetShortArray(JNIEnv* env, jclass, jlong bptr, jshortArray v)
 {
     ObjectBuffer* buf = (ObjectBuffer*)bptr;
     size_t len = 0;
-    SHORT* elems = NULL;
+    short* elems = NULL;
     if (v != NULL) { 
         jshort* shorts = env->GetShortArrayElements(v, 0);
         len = env->GetArrayLength(v);

--- a/jnicli/jnicli.cpp
+++ b/jnicli/jnicli.cpp
@@ -837,7 +837,7 @@ jobjectArray JNICALL jniGetStringArray(JNIEnv* env, jclass, jlong cursor)
     return ((JniResultSet*)cursor)->nextStringArray(env);
 }
 
-jint JNICALL    jniGetNumberOfSelectedRecords(JNIEnv* env, jclass, long cursor)
+jint JNICALL    jniGetNumberOfSelectedRecords(JNIEnv* env, jclass, jlong cursor)
 {
     return ((JniResultSet*)cursor)->size();
 }

--- a/makefile
+++ b/makefile
@@ -432,10 +432,10 @@ examples/JniTestRelations.class: examples/JniTestRelations.java jnicli.jar
 	javac -classpath jnicli.jar examples/JniTestRelations.java
 
 examples/CliTest.class: examples/CliTest.java javacli.jar
-	javac -classpath .;javacli.jar examples/CliTest.java
+	javac -classpath javacli.jar examples/CliTest.java
 
 examples/TestIndex.class: examples/TestIndex.java javacli.jar
-	javac -classpath .;javacli.jar examples/TestIndex.java
+	javac -classpath javacli.jar examples/TestIndex.java
 
 install: subsql cleanupsem inspectsem installlib
 	mkdir -p $(BINSPATH)

--- a/makefile.mvc
+++ b/makefile.mvc
@@ -403,10 +403,10 @@ jnicli.jar: jnicli\*.java
 	javadoc -d jnicli/docs -public jnicli\*.java
 
 examples/CliTest.class: examples/CliTest.java javacli.jar
-	javac -classpath .;javacli.jar examples\CliTest.java
+	javac -classpath javacli.jar examples\CliTest.java
 
 examples/TestIndex.class: examples/TestIndex.java javacli.jar
-	javac -classpath .;javacli.jar examples\TestIndex.java
+	javac -classpath javacli.jar examples\TestIndex.java
 
 examples/JniTestIndex.class: examples/JniTestIndex.java jnicli.jar
 	javac -g -classpath jnicli.jar examples\JniTestIndex.java

--- a/makefile.sun
+++ b/makefile.sun
@@ -409,10 +409,10 @@ examples/JniTestRelations.class: examples/JniTestRelations.java jnicli.jar
 	javac -classpath jnicli.jar examples/JniTestRelations.java
 
 examples/CliTest.class: examples/CliTest.java javacli.jar
-	javac -classpath .;javacli.jar examples/CliTest.java
+	javac -classpath javacli.jar examples/CliTest.java
 
 examples/TestIndex.class: examples/TestIndex.java javacli.jar
-	javac -classpath .;javacli.jar examples/TestIndex.java
+	javac -classpath javacli.jar examples/TestIndex.java
 
 install: subsql cleanupsem installlib
 	mkdir -p $(BINSPATH)


### PR DESCRIPTION
The `makefile` changes are needed for Unix (see [this](https://stackoverflow.com/questions/460364/how-to-use-classes-from-jar-files/2817176#2817176)) but will still work on Windows since the jars are already in the same folder as the `makefile`s.