### PR TITLE
Remove erroneous assert

### DIFF
--- a/src/class.cpp
+++ b/src/class.cpp
@@ -1568,10 +1568,6 @@ bool dbTableDescriptor::match(dbTable* table, bool confirmDeleteColumns, bool is
             }
         }
     }
-    if (!confirmDeleteColumns) {             
-        assert(((void)"field can be removed only from empty table",
-                nFields==nMatches));
-    }
     return formatNotChanged;
 }
 


### PR DESCRIPTION
The assert fails even in benign cases of simply opening the DB, not even deleting any column (not sure whether some shared memory/semaphore not being deleted properly could be the root cause).